### PR TITLE
Update db-shcheduler-mongo to use new db-scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
     <!--  Versions declaration  -->
-    <db-scheduler.version>9.3</db-scheduler.version>
-    <mongo-java-driver.version>3.12.7</mongo-java-driver.version>
-    <slf4j-simple.version>1.7.30</slf4j-simple.version>
-    <embed-mongo.version>3.0.0</embed-mongo.version>
-    <junit-jupiter.version>5.6.0</junit-jupiter.version>
-    <mockito-core.version>3.7.7</mockito-core.version>
-    <assertj-version>3.19.0</assertj-version>
-    <guava.version>30.1-jre</guava.version>
+    <db-scheduler.version>11.6</db-scheduler.version>
+    <mongodb-driver.version>4.8.1</mongodb-driver.version>
+    <slf4j.version>2.17.1</slf4j.version>
+    <embed-mongo.version>4.3.3</embed-mongo.version>
+    <junit-jupiter.version>5.9.1</junit-jupiter.version>
+    <mockito-core.version>4.11.0</mockito-core.version>
+    <assertj-version>3.24.0</assertj-version>
+    <guava.version>31.1-jre</guava.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
   </properties>
 
@@ -37,16 +37,36 @@
 
     <dependency>
       <groupId>org.mongodb</groupId>
-      <artifactId>mongo-java-driver</artifactId>
-      <version>${mongo-java-driver.version}</version>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <version>${mongodb-driver.version}</version>
     </dependency>
 
-    <!--  Tests dependencies  -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-core</artifactId>
+      <version>${mongodb-driver.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>bson</artifactId>
+      <version>${mongodb-driver.version}</version>
+    </dependency>
+
+
+
+    <!--    <dependency>-->
+<!--      <groupId>org.mongodb</groupId>-->
+<!--      <artifactId>mongo-java-driver</artifactId>-->
+<!--      <version>${mongo-java-driver.version}</version>-->
+<!--    </dependency>-->
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
 
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
@@ -105,10 +125,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j-simple.version}</version>
-        <scope>test</scope>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <version>${slf4j.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,6 @@
       <version>${mongodb-driver.version}</version>
     </dependency>
 
-
-
-    <!--    <dependency>-->
-<!--      <groupId>org.mongodb</groupId>-->
-<!--      <artifactId>mongo-java-driver</artifactId>-->
-<!--      <version>${mongo-java-driver.version}</version>-->
-<!--    </dependency>-->
-
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>

--- a/src/main/java/com/github/kagkarlsson/scheduler/MongoScheduler.java
+++ b/src/main/java/com/github/kagkarlsson/scheduler/MongoScheduler.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.OnStartup;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.mongodb.client.MongoClient;
 
+import javax.sql.DataSource;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,10 +22,17 @@ public class MongoScheduler extends Scheduler {
             statsRegistry, pollingStrategyConfig, deleteUnresolvedAfter, shutdownMaxWait, logLevel, logStackTrace, onStartup);
     }
 
+    public static SchedulerBuilder create(MongoClient mongoClient, String database, Task<?> ... knownTasks) {
+        return create(mongoClient, database, Arrays.asList(knownTasks));
+    }
+
     public static MongoSchedulerBuilder create(MongoClient mongoClient, String database,
                                                String collection, Task<?>... knownTasks) {
-        List<Task<?>> knownTasksList = new ArrayList<>(Arrays.asList(knownTasks));
-        return create(mongoClient, database, collection, knownTasksList);
+        return create(mongoClient, database, collection, Arrays.asList(knownTasks));
+    }
+
+    public static MongoSchedulerBuilder create(MongoClient mongoClient, String database, List<Task<?>> knownTasks) {
+        return new MongoSchedulerBuilder(mongoClient, database, knownTasks);
     }
 
     public static MongoSchedulerBuilder create(MongoClient mongoClient, String database,

--- a/src/main/java/com/github/kagkarlsson/scheduler/MongoScheduler.java
+++ b/src/main/java/com/github/kagkarlsson/scheduler/MongoScheduler.java
@@ -1,9 +1,11 @@
 package com.github.kagkarlsson.scheduler;
 
+import com.github.kagkarlsson.scheduler.logging.LogLevel;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.OnStartup;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,25 +14,16 @@ import java.util.concurrent.ExecutorService;
 
 public class MongoScheduler extends Scheduler {
 
-    protected MongoScheduler(Clock clock,
-        TaskRepository schedulerTaskRepository,
-        TaskRepository clientTaskRepository, TaskResolver taskResolver, int threadpoolSize,
-        ExecutorService executorService,
-        SchedulerName schedulerName, Waiter executeDueWaiter, Duration heartbeatInterval,
-        boolean enableImmediateExecution,
-        StatsRegistry statsRegistry, int pollingLimit,
-        Duration deleteUnresolvedAfter, Duration shutdownMaxWait,
-        List<OnStartup> onStartup) {
+    protected MongoScheduler(Clock clock, TaskRepository schedulerTaskRepository, TaskRepository clientTaskRepository, TaskResolver taskResolver, int threadpoolSize, ExecutorService executorService, SchedulerName schedulerName, Waiter executeDueWaiter, Duration heartbeatInterval, boolean enableImmediateExecution, StatsRegistry statsRegistry, PollingStrategyConfig pollingStrategyConfig, Duration deleteUnresolvedAfter, Duration shutdownMaxWait, LogLevel logLevel, boolean logStackTrace, List<OnStartup> onStartup) {
         super(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, threadpoolSize,
             executorService, schedulerName, executeDueWaiter, heartbeatInterval,
             enableImmediateExecution,
-            statsRegistry, pollingLimit, deleteUnresolvedAfter, shutdownMaxWait, onStartup);
+            statsRegistry, pollingStrategyConfig, deleteUnresolvedAfter, shutdownMaxWait, logLevel, logStackTrace, onStartup);
     }
 
     public static MongoSchedulerBuilder create(MongoClient mongoClient, String database,
-        String collection, Task<?>... knownTasks) {
-        List<Task<?>> knownTasksList = new ArrayList<>();
-        knownTasksList.addAll(Arrays.asList(knownTasks));
+                                               String collection, Task<?>... knownTasks) {
+        List<Task<?>> knownTasksList = new ArrayList<>(Arrays.asList(knownTasks));
         return create(mongoClient, database, collection, knownTasksList);
     }
 

--- a/src/main/java/com/github/kagkarlsson/scheduler/MongoSchedulerBuilder.java
+++ b/src/main/java/com/github/kagkarlsson/scheduler/MongoSchedulerBuilder.java
@@ -39,6 +39,21 @@ public class MongoSchedulerBuilder extends SchedulerBuilder {
         this.tableName = collection;
     }
 
+    /**
+     * Scheduler builder for mongo database
+     *
+     * Example using the database 'scheduler-database' and the collection 'scheduler-collection' :
+     * SchedulerBuilder builder = new MongoSchedulerBuilder(mongoTools.getClient(), knownTasks).tableName("scheduler-collection")
+     *
+     * @param mongoClient - object handling mongo connection
+     * @param knownTasks - list of known tasks
+     */
+    protected MongoSchedulerBuilder(MongoClient mongoClient, String databaseName, List<Task<?>> knownTasks) {
+        super(null, knownTasks);
+        this.databaseName = databaseName;
+        this.mongoClient = mongoClient;
+    }
+
     public MongoSchedulerBuilder registerShutdownHook() {
         this.registerShutdownHook = true;
         return this;
@@ -46,10 +61,6 @@ public class MongoSchedulerBuilder extends SchedulerBuilder {
 
     @Override
     public Scheduler build() {
-//        if (pollingLimit < executorThreads) {
-//            LOG.warn("Polling-limit is less than number of threads. Should be equal or higher.");
-//        }
-
         if (schedulerName == null) {
             schedulerName = new SchedulerName.Hostname();
         }

--- a/src/main/java/com/github/kagkarlsson/scheduler/MongoTaskRepository.java
+++ b/src/main/java/com/github/kagkarlsson/scheduler/MongoTaskRepository.java
@@ -326,12 +326,20 @@ public class MongoTaskRepository implements TaskRepository {
         final FindOneAndUpdateOptions options = new FindOneAndUpdateOptions();
         options.upsert(false);
 
-        Bson update = combine(set(Fields.executionTime, nextExecutionTime),
-            set(Fields.taskData, serializer.serialize(data)),
-            set(Fields.lastSuccess, lastSuccess), set(Fields.lastFailure, lastFailure),
+        Bson update = combine(
+            set(Fields.executionTime, nextExecutionTime),
+            set(Fields.lastSuccess, Optional.ofNullable(lastSuccess).orElse(null)),
+            set(Fields.lastFailure, Optional.ofNullable(lastFailure).orElse(null)),
             set(Fields.consecutiveFailures, consecutiveFailures),
-            inc(Fields.version, 1));
+            set(Fields.picked, false),
+            set(Fields.pickedBy, null),
+            set(Fields.lastHeartbeat, null),
+            inc(Fields.version, 1)
+        );
 
+        if(data != null){
+            update = combine(update, set(Fields.taskData, serializer.serialize(data)));
+        }
         final TaskEntity document = this.collection
             .findOneAndUpdate(buildFilterFromExecution(execution), update, options);
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="ERROR">
+        <Root level="INFO">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="INFO">
+        <Root level="ERROR">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/src/test/java/com/github/kagkarlsson/scheduler/EmebddedMongodbExtension.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/EmebddedMongodbExtension.java
@@ -5,8 +5,8 @@ import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
 import com.github.kagkarlsson.scheduler.utils.TestUtils;
 import com.github.kagkarlsson.scheduler.utils.TestUtils.MongoTools;
-import com.mongodb.MongoClient;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import java.io.IOException;
@@ -52,19 +52,18 @@ public class EmebddedMongodbExtension implements AfterEachCallback, AfterAllCall
 
     private MongoCollection<TaskEntity> getCollection(MongoDatabase db,
         String collectionName) {
-        MongoCollection<TaskEntity> collection = db
+        return db
             .getCollection(collectionName, TaskEntity.class);
-        return collection;
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws Exception {
+    public void afterEach(ExtensionContext extensionContext) {
         LOG.info("Delete collection");
         this.collection.deleteMany(new Document());
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) throws Exception {
+    public void afterAll(ExtensionContext extensionContext) {
         LOG.info("Kill embedded mongo");
         this.mongoTools.getMongodProcess().stop();
     }

--- a/src/test/java/com/github/kagkarlsson/scheduler/MongoSchedulerTest.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/MongoSchedulerTest.java
@@ -23,7 +23,7 @@ public class MongoSchedulerTest {
     @Test
     void schedulerOneTimeTest() {
         SchedulerBuilder builder = MongoScheduler
-            .create(mongo.getMongoClient(), "database", "collection");
+            .create(mongo.getMongoClient(), "db-scheduler-mongo");
 
         AtomicInteger count = new AtomicInteger();
 

--- a/src/test/java/com/github/kagkarlsson/scheduler/MongoTaskRepositoryTest.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/MongoTaskRepositoryTest.java
@@ -1,11 +1,13 @@
 package com.github.kagkarlsson.scheduler;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
-import com.github.kagkarlsson.scheduler.task.Execution;
-import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.serializer.Serializer;
+import com.github.kagkarlsson.scheduler.task.*;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import com.github.kagkarlsson.scheduler.utils.ExecutionBuilder;
 import com.github.kagkarlsson.scheduler.utils.TestUtils;
 import com.mongodb.ErrorCategory;
@@ -19,12 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Assertions;
@@ -50,31 +47,44 @@ public class MongoTaskRepositoryTest {
 
     private MongoTaskRepository repository;
 
+    private OneTimeTask<Void> oneTimeTask;
+
     @RegisterExtension
     protected static EmebddedMongodbExtension emebddedMongodbExtension = new EmebddedMongodbExtension();
 
     @BeforeEach
-    void init() throws IOException {
+    void init() {
         // Mock task resolver
         Task taskResolved = Mockito.mock(Task.class);
         Mockito.lenient().when(taskResolved.getDataClass()).thenReturn(SimpleData.class);
         Mockito.lenient().when(taskResolver.resolve(Mockito.anyString()))
             .thenReturn(Optional.of(taskResolved));
+        oneTimeTask = MongoTaskRepositoryTest.oneTime("idTask", Void.class, (e, b) -> {});
 
         repository = new MongoTaskRepository(taskResolver, schedulerName, serializer,
-            "db-scheduler", "db-scheduler", emebddedMongodbExtension.getMongoClient());
+            "db-scheduler", "db-scheduler", emebddedMongodbExtension.getMongoClient(), new SettableClock());
+    }
+
+    public static <T> OneTimeTask<T> oneTime(String name, Class<T> dataClass, VoidExecutionHandler<T> handler) {
+        return new OneTimeTask<T>(name, dataClass) {
+            @Override
+            public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                handler.execute(taskInstance, executionContext);
+            }
+        };
     }
 
     @Test
     void testCreateIfNotExistsOk() {
-        Execution execution = new ExecutionBuilder().taskName("idTask").taskInstanceId("idInstance")
-            .build();
 
-        boolean created = repository.createIfNotExists(execution);
+        TaskInstance<Void> task = oneTimeTask.instance("id1");
+        SchedulableTaskInstance instance = new SchedulableTaskInstance<>(task, Instant.now().truncatedTo(MILLIS));
+
+        boolean created = repository.createIfNotExists(instance);
 
         assertThat(created).isTrue();
 
-        MongoDatabase db = this.emebddedMongodbExtension.getDb();
+        MongoDatabase db = emebddedMongodbExtension.getDb();
 
         MongoIterable<String> collections = db.listCollectionNames();
 
@@ -83,27 +93,27 @@ public class MongoTaskRepositoryTest {
         assertThat(collectionName).isEqualTo("db-scheduler");
 
         // Check presence in collection
-        MongoCollection<TaskEntity> collection = this.emebddedMongodbExtension.getCollection();
+        MongoCollection<TaskEntity> collection = emebddedMongodbExtension.getCollection();
 
         TaskEntity taskEntity = collection.find().first();
 
         assertThat(taskEntity).isNotNull();
-        assertThat(taskEntity.getTaskName()).isEqualTo("idTask");
-        assertThat(taskEntity.getTaskInstance()).isEqualTo("idInstance");
+        assertThat(taskEntity.getTaskName()).isEqualTo(task.getTaskName());
+        assertThat(taskEntity.getTaskInstance()).isEqualTo(task.getId());
     }
 
     @Test
-    void testCreateIfNotExistsKo() {
-        Execution execution = new ExecutionBuilder().taskName("idTask").taskInstanceId("idInstance")
-            .build();
+    void testCreateIfExistsOk() {
+        TaskInstance<Void> task = oneTimeTask.instance("id1");
+        SchedulableTaskInstance instance = new SchedulableTaskInstance<>(task, Instant.now().truncatedTo(MILLIS));
 
         TaskEntity taskEntityInitial = new TaskEntity();
-        taskEntityInitial.setTaskInstance("idInstance");
-        taskEntityInitial.setTaskName("idTask");
+        taskEntityInitial.setTaskInstance(task.getId());
+        taskEntityInitial.setTaskName(task.getTaskName());
 
-        this.emebddedMongodbExtension.getCollection().insertOne(taskEntityInitial);
+        emebddedMongodbExtension.getCollection().insertOne(taskEntityInitial);
 
-        boolean created = repository.createIfNotExists(execution);
+        boolean created = repository.createIfNotExists(instance);
         // Check that no execution is created because it already exists
         assertThat(created).isFalse();
     }
@@ -117,7 +127,7 @@ public class MongoTaskRepositoryTest {
         UnresolvedTask unresolvedTask = Mockito.mock(UnresolvedTask.class);
         Mockito.when(unresolvedTask.getTaskName()).thenReturn("unresolved");
 
-        Mockito.when(taskResolver.getUnresolved()).thenReturn(Arrays.asList(unresolvedTask));
+        Mockito.when(taskResolver.getUnresolved()).thenReturn(Collections.singletonList(unresolvedTask));
 
         // Insert test data in mongo
         // | Task name  | Task instance | picked | execution time | Should be selected |
@@ -143,7 +153,7 @@ public class MongoTaskRepositoryTest {
 
         // Insert 4 executions, 3 of them are not picked, 2 of those are in the past
         // 1 of them is picked and in the past
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         // ACT
         List<Execution> executions = repository.getDue(Instant.now(), 10);
@@ -182,7 +192,7 @@ public class MongoTaskRepositoryTest {
                     .executionTime(Instant.now().plus(2, ChronoUnit.MINUTES))
                     .build());
 
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(false);
         List<Execution> executions = new ArrayList<>();
@@ -221,7 +231,7 @@ public class MongoTaskRepositoryTest {
                     .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
                     .build());
 
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(true);
         List<Execution> executions = new ArrayList<>();
@@ -265,7 +275,7 @@ public class MongoTaskRepositoryTest {
                     .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
                     .build());
 
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
         // Build method parameter for call
         ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(false);
         List<Execution> executions = new ArrayList<>();
@@ -304,7 +314,7 @@ public class MongoTaskRepositoryTest {
                     .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
                     .build());
 
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
         // Build method parameter for call
         ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(true);
         List<Execution> executions = new ArrayList<>();
@@ -335,7 +345,7 @@ public class MongoTaskRepositoryTest {
         List<TaskEntity> entities = Arrays
             .asList(builder.version(0L).picked(false).taskInstance("instance-1").build(),
                 builder.version(1).picked(true).taskInstance("instance-2").build());
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         // Parameter construction
         Execution execution = new ExecutionBuilder().taskName("task-1").taskInstanceId("instance-2")
@@ -345,7 +355,7 @@ public class MongoTaskRepositoryTest {
 
         List<TaskEntity> tasks = StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
-                this.emebddedMongodbExtension.getCollection().find().iterator(),
+                emebddedMongodbExtension.getCollection().find().iterator(),
                 Spliterator.ORDERED), false).collect(Collectors.toList());
 
         assertThat(tasks).isNotEmpty();
@@ -360,7 +370,7 @@ public class MongoTaskRepositoryTest {
             .taskInstance("taskInstance")
             .executionTime(Instant.now()).consecutiveFailures(3).version(12)
             .build();
-        this.emebddedMongodbExtension.getCollection().insertOne(task);
+        emebddedMongodbExtension.getCollection().insertOne(task);
 
         // Build method parameter
         SimpleData dataContent = new SimpleData("content");
@@ -383,7 +393,7 @@ public class MongoTaskRepositoryTest {
         assertThat(updated).isTrue();
 
         // Retrieve actual object in database
-        TaskEntity actual = this.emebddedMongodbExtension.getCollection().find().first();
+        TaskEntity actual = emebddedMongodbExtension.getCollection().find().first();
         // Test if task is correctly updated with parameters
         assertThat(actual).isNotEqualTo(task);
         assertThat(actual.getVersion()).isEqualTo(execution.version + 1);
@@ -402,7 +412,7 @@ public class MongoTaskRepositoryTest {
             .taskInstance("taskInstance")
             .executionTime(Instant.now()).consecutiveFailures(3).version(12)
             .build();
-        this.emebddedMongodbExtension.getCollection().insertOne(task);
+        emebddedMongodbExtension.getCollection().insertOne(task);
 
         // Build method parameter
         Execution execution = new ExecutionBuilder().taskName("name-1").version(12)
@@ -443,7 +453,7 @@ public class MongoTaskRepositoryTest {
         TaskEntity task = TaskEntityBuilder.aTaskEntity().taskName("name-1")
             .taskInstance("taskInstance").executionTime(Instant.now())
             .picked(false).version(version).taskData("test".getBytes()).build();
-        this.emebddedMongodbExtension.getCollection().insertOne(task);
+        emebddedMongodbExtension.getCollection().insertOne(task);
 
         // Build method parameter
         Execution execution = new ExecutionBuilder().taskName("name-1").version(version)
@@ -509,7 +519,7 @@ public class MongoTaskRepositoryTest {
                     .lastHeartbeat(Instant.now().minus(1, ChronoUnit.HOURS))
                     .build());
 
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         // Act
         Instant olderThan = Instant.now().minus(30, ChronoUnit.MINUTES);
@@ -529,7 +539,7 @@ public class MongoTaskRepositoryTest {
             .taskInstance("instance-1").version(12)
             .lastHeartbeat(initialHeartBeat).build();
 
-        this.emebddedMongodbExtension.getCollection().insertOne(task);
+        emebddedMongodbExtension.getCollection().insertOne(task);
 
         // Build arguments
         Execution execution = new ExecutionBuilder().taskName("task-1").taskInstanceId("instance-1")
@@ -538,7 +548,7 @@ public class MongoTaskRepositoryTest {
 
         repository.updateHeartbeat(execution, newHeartbeat);
 
-        TaskEntity actual = this.emebddedMongodbExtension.getCollection().find().first();
+        TaskEntity actual = emebddedMongodbExtension.getCollection().find().first();
         assertThat(actual).isNotEqualTo(task);
         assertThat(actual.getLastHeartbeat()).isEqualTo(TestUtils.truncateInstant(newHeartbeat));
     }
@@ -565,7 +575,7 @@ public class MongoTaskRepositoryTest {
                 .lastSuccess(Instant.now().minus(1, ChronoUnit.HOURS))
                 .lastFailure(null).build());
 
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         // Build argument
         Duration interval = Duration.ofMinutes(30);
@@ -582,7 +592,7 @@ public class MongoTaskRepositoryTest {
         TaskEntity entity = TaskEntityBuilder.aTaskEntity().taskName("task-1")
             .taskInstance("instance-1").build();
 
-        this.emebddedMongodbExtension.getCollection().insertOne(entity);
+        emebddedMongodbExtension.getCollection().insertOne(entity);
 
         // Call method
         Optional<Execution> actual = repository.getExecution("task-1", "instance-1");
@@ -605,7 +615,7 @@ public class MongoTaskRepositoryTest {
         List<TaskEntity> entities = Arrays.asList(builder.taskInstance("instance-1").build(),
             builder.taskInstance("instance-2").build(), builder.taskInstance("instance-3").build(),
             builder.taskName("task-2").taskInstance("instance-1").build());
-        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        emebddedMongodbExtension.getCollection().insertMany(entities);
 
         // Call method
         int deletedCount = repository.removeExecutions("task-1");
@@ -613,7 +623,7 @@ public class MongoTaskRepositoryTest {
         assertThat(deletedCount).isEqualTo(3);
 
         List<TaskEntity> actual = StreamSupport
-            .stream(this.emebddedMongodbExtension.getCollection().find().spliterator(), false)
+            .stream(emebddedMongodbExtension.getCollection().find().spliterator(), false)
             .collect(Collectors.toList());
 
         assertThat(actual).hasSize(1);
@@ -628,14 +638,14 @@ public class MongoTaskRepositoryTest {
         List<TaskEntity> entities = Arrays.asList(builder.build(), builder.build());
         MongoBulkWriteException bulkException = Assertions
             .assertThrows(MongoBulkWriteException.class,
-                () -> this.emebddedMongodbExtension.getCollection().insertMany(entities));
+                () -> emebddedMongodbExtension.getCollection().insertMany(entities));
 
         MongoWriteException exception = Assertions
             .assertThrows(MongoWriteException.class,
-                () -> this.emebddedMongodbExtension.getCollection().insertOne(builder.build()));
+                () -> emebddedMongodbExtension.getCollection().insertOne(builder.build()));
 
         List<TaskEntity> actualEntities = StreamSupport
-            .stream(this.emebddedMongodbExtension.getCollection().find().spliterator(), false)
+            .stream(emebddedMongodbExtension.getCollection().find().spliterator(), false)
             .collect(Collectors.toList());
 
         // Check exception

--- a/src/test/java/com/github/kagkarlsson/scheduler/MongoTaskRepositoryTest.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/MongoTaskRepositoryTest.java
@@ -270,7 +270,7 @@ public class MongoTaskRepositoryTest {
     }
 
     @Test
-    void testScheduledExecutionsWithPicekd() {
+    void testScheduledExecutionsWithPicked() {
         // Insert test data in mongo
         // | Task name | Task instance | picked | execution time | Should be selected |
         // |-----------|---------------|--------|----------------|--------------------|
@@ -590,7 +590,7 @@ public class MongoTaskRepositoryTest {
 
     @Test
     void testUpdateHeartbeat() {
-        // Build entity to insert in databse
+        // Build entity to insert in database
         Instant initialHeartBeat = Instant.now()
             .minus(1, ChronoUnit.HOURS);
         TaskEntity task = TaskEntityBuilder.aTaskEntity().taskName("task-1")

--- a/src/test/java/com/github/kagkarlsson/scheduler/example/MongoDbSimpleTaskMain.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/example/MongoDbSimpleTaskMain.java
@@ -9,7 +9,10 @@ import com.github.kagkarlsson.scheduler.task.ExecutionContext;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
 import com.github.kagkarlsson.scheduler.utils.TestUtils;
 import com.github.kagkarlsson.scheduler.utils.TestUtils.MongoTools;
 import java.io.IOException;
@@ -34,24 +37,35 @@ public class MongoDbSimpleTaskMain {
         OneTimeTask<SampleTaskData> oneTimeTask = Tasks.oneTime("one-time", SampleTaskData.class)
             .execute((TaskInstance<SampleTaskData> inst, ExecutionContext ctx) -> LOG.info("Trigger of execution {}, with data {}", ctx.getExecution(), inst));
 
+        Schedule cron = Schedules.cron("*/10 * * * * ?");
+        RecurringTask<Void> recurringTask = Tasks.recurring("cron-task", cron)
+                .execute((taskInstance, executionContext) -> LOG.info(Instant.now().getEpochSecond() + "s  -  Cron-schedule!"));
+
+
         // Instantiation of mongodb based scheduler
         List<Task<?>> knownTasks = new ArrayList<>();
         // Register the one time task to scheduler
         knownTasks.add(oneTimeTask);
+        knownTasks.add(recurringTask);
 
-        SchedulerBuilder builder = MongoScheduler
-            .create(mongoTools.getClient(), "scheduler-database", "scheduler-collection",
-                knownTasks)
-                .pollingInterval(Duration.ofSeconds(5));
-        Scheduler scheduler = builder.build();
+        String databaseName = "scheduler-database";
+        String collectionName = "scheduler-collection";
+        Scheduler scheduler = MongoScheduler
+                .create(mongoTools.getClient(),
+                        databaseName,
+                        collectionName,
+                        knownTasks)
+                .pollingInterval(Duration.ofSeconds(1))
+                .build();
         // Start scheduler
         scheduler.start();
         // Start one time task
         scheduler.schedule(oneTimeTask.instance("test-instance"),
-            Instant.now().plus(5, ChronoUnit.SECONDS));
+            Instant.now().plus(10, ChronoUnit.SECONDS));
+        scheduler.schedule(recurringTask.schedulableInstance("rec-id"));
 
-        Document task = mongoTools.getClient().getDatabase("scheduler-database")
-            .getCollection("scheduler-collection").find().first();
+        Document task = mongoTools.getClient().getDatabase(databaseName)
+            .getCollection(collectionName).find().first();
         LOG.info("Task found {}", task);
 
         // Proper shutdown of the scheduler

--- a/src/test/java/com/github/kagkarlsson/scheduler/example/MongoDbSimpleTaskMain.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/example/MongoDbSimpleTaskMain.java
@@ -32,9 +32,7 @@ public class MongoDbSimpleTaskMain {
 
         // Simple Task
         OneTimeTask<SampleTaskData> oneTimeTask = Tasks.oneTime("one-time", SampleTaskData.class)
-            .execute((TaskInstance<SampleTaskData> inst, ExecutionContext ctx) -> {
-                LOG.info("Trigger of execution {}, with data {}", ctx.getExecution(), inst);
-            });
+            .execute((TaskInstance<SampleTaskData> inst, ExecutionContext ctx) -> LOG.info("Trigger of execution {}, with data {}", ctx.getExecution(), inst));
 
         // Instantiation of mongodb based scheduler
         List<Task<?>> knownTasks = new ArrayList<>();
@@ -43,7 +41,8 @@ public class MongoDbSimpleTaskMain {
 
         SchedulerBuilder builder = MongoScheduler
             .create(mongoTools.getClient(), "scheduler-database", "scheduler-collection",
-                knownTasks).pollingInterval(Duration.ofSeconds(5));
+                knownTasks)
+                .pollingInterval(Duration.ofSeconds(5));
         Scheduler scheduler = builder.build();
         // Start scheduler
         scheduler.start();
@@ -59,7 +58,6 @@ public class MongoDbSimpleTaskMain {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             LOG.info("Received shutdown signal.");
             scheduler.stop();
-            mongoTools.getMongodExecutable().stop();
             mongoTools.getMongodProcess().stop();
         }));
 

--- a/src/test/java/com/github/kagkarlsson/scheduler/utils/TestTasks.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/utils/TestTasks.java
@@ -1,0 +1,23 @@
+package com.github.kagkarlsson.scheduler.utils;
+
+import com.github.kagkarlsson.scheduler.task.CompletionHandler;
+import com.github.kagkarlsson.scheduler.task.ExecutionContext;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.VoidExecutionHandler;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+
+public class TestTasks {
+
+    public static final CompletionHandler<Void> REMOVE_ON_COMPLETE = new CompletionHandler.OnCompleteRemove<>();
+    public static final VoidExecutionHandler<Void> DO_NOTHING = (taskInstance, executionContext) -> {};
+
+    public static <T> OneTimeTask<T> oneTime(String name, Class<T> dataClass, VoidExecutionHandler<T> handler) {
+        return new OneTimeTask<T>(name, dataClass) {
+            @Override
+            public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                handler.execute(taskInstance, executionContext);
+            }
+        };
+    }
+
+}

--- a/src/test/java/com/github/kagkarlsson/scheduler/utils/TestUtils.java
+++ b/src/test/java/com/github/kagkarlsson/scheduler/utils/TestUtils.java
@@ -52,7 +52,7 @@ public class TestUtils {
 
     public static MongoTools startEmbeddedMongo() throws IOException {
         InetAddress localHost = Network.getLocalHost();
-        int freeServerPort = Network.freeServerPort(localHost);
+        int freeServerPort = 27017;//Network.freeServerPort(localHost);
 
         Mongod mongod = new Mongod() {
             @Override


### PR DESCRIPTION
Hi.
I changed the implementation to use latest version of  db-scheduler (11.6).

for 'LockAndFetch' method, i could not find any solution in mongodb to support 'SELECT... FOR UPDATE SKIP LOCKED'.